### PR TITLE
Provide missing OpenOCD configuration for STM32F3DISCOVERY

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
     rustup target add thumbv7em-none-eabihf
     cd example-stm32f303vc
-    openocd -f board/stm32f3discovery.cfg &
+    openocd -f openocd.cfg &
     cargo run --release
 
 ### STM32F042K6 ([NUCLEO-F042K6](https://www.st.com/en/evaluation-tools/nucleo-f042k6.html) board)

--- a/example-stm32f303vc/openocd.cfg
+++ b/example-stm32f303vc/openocd.cfg
@@ -1,0 +1,5 @@
+# Sample OpenOCD configuration for the STM32F3DISCOVERY development board
+
+source [find interface/stlink.cfg]
+
+source [find target/stm32f3x.cfg]


### PR DESCRIPTION
The OpenOCD configuration `board/stm32f3discovery.cfg` mentioned in `README.md` is not present in the repository. I copied `openocd.cfg` from the Blue Pill example and was surprised to see `Sample OpenOCD configuration for the STM32F3DISCOVERY development board` in it. So it should do the trick, I guessed and it did.

Thank you for this awesome example! I got it up and running within minues.