### PR TITLE
Update examples to stm32-usbd v0.5

### DIFF
--- a/example-stm32f042k6/Cargo.toml
+++ b/example-stm32f042k6/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.6"
 cortex-m-rt = "0.6"
-stm32f0xx-hal = { version = "0.15.2", features = ["rt", "stm32f042"] }
+stm32f0xx-hal = { version = "0.17", features = ["stm32f042", "stm32-usbd"] }
 panic-semihosting = "0.5"
 usb-device = "0.2.1"
 usbd-serial = "0.1"
-stm32-usbd = { version = "0.4.0", features = ["stm32f042xx"] }
+stm32-usbd = { version = "0.5", features = ["ram_access_2x16"] }

--- a/example-stm32f042k6/src/main.rs
+++ b/example-stm32f042k6/src/main.rs
@@ -6,7 +6,7 @@ extern crate panic_semihosting;
 
 use cortex_m_rt::entry;
 use stm32_usbd::UsbBus;
-use stm32f0xx_hal::{prelude::*, stm32};
+use stm32f0xx_hal::{prelude::*, stm32, usb::Peripheral};
 use usb_device::prelude::*;
 use usbd_serial::{SerialPort, USB_CLASS_CDC};
 
@@ -39,10 +39,13 @@ fn main() -> ! {
 
     let gpioa = dp.GPIOA.split(&mut rcc);
 
-    let usb_dm = gpioa.pa11;
-    let usb_dp = gpioa.pa12;
+    let usb = Peripheral {
+        usb: dp.USB,
+        pin_dm: gpioa.pa11,
+        pin_dp: gpioa.pa12,
+    };
 
-    let usb_bus = UsbBus::new(dp.USB, (usb_dm, usb_dp));
+    let usb_bus = UsbBus::new(usb);
 
     let mut serial = SerialPort::new(&usb_bus);
 


### PR DESCRIPTION
I ended up needing `stm32-usbd` and found that these examples are out of date with current versions of both the HAL libraries as well as `stm32-usbd`. This PR updates the stm32f042k6 example to use `stm32f0xx-hal` v0.17 and `stm32-usbd` v0.5. I only updated this example since I only have a `stm32f042k6` device to test changes on. If you want I can also try to update the other examples, but I won't be able to test those on real devices.